### PR TITLE
DEV-34631 Add a flag to manage annotation and instances to process request

### DIFF
--- a/pkg/services/ngalert/api/logzio_alerting_api.go
+++ b/pkg/services/ngalert/api/logzio_alerting_api.go
@@ -51,7 +51,7 @@ func (api *LogzioAlertingApi) RouteProcessAlert(ctx *models.ReqContext) response
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	return api.service.RouteProcessAlert(body)
+	return api.service.RouteProcessAlert(*ctx.Req, body)
 }
 
 func (api *LogzioAlertingApi) RouteMigrateOrg(ctx *models.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -469,8 +469,9 @@ type AlertEvaluationRequest struct {
 }
 
 type AlertProcessRequest struct {
-	AlertRule         ApiAlertRule    `json:"alertRule"`
-	EvaluationResults []ApiEvalResult `json:"evaluationResults"`
+	ShouldManageAnnotationsAndInstances *bool           `json:"shouldManageAnnotationsAndInstances"`
+	AlertRule                           ApiAlertRule    `json:"alertRule"`
+	EvaluationResults                   []ApiEvalResult `json:"evaluationResults"`
 }
 
 type ApiAlertRule struct {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -388,9 +388,12 @@ func (st *Manager) staleResultsHandler(ctx context.Context, alertRule *ngModels.
 		}
 	}
 
-	if err := st.instanceStore.DeleteAlertInstances(ctx, toDelete...); err != nil {
-		st.log.Error("unable to delete stale instances from database", "err", err.Error(),
-			"orgID", alertRule.OrgID, "alertRuleUID", alertRule.UID, "count", len(toDelete))
+	shouldManageInstances := ctx.Value(ShouldManageAnnotationsAndInstancesContextKey).(bool)
+	if shouldManageInstances {
+		if err := st.instanceStore.DeleteAlertInstances(ctx, toDelete...); err != nil {
+			st.log.Error("unable to delete stale instances from database", "err", err.Error(),
+				"orgID", alertRule.OrgID, "alertRuleUID", alertRule.UID, "count", len(toDelete))
+		}
 	}
 }
 


### PR DESCRIPTION
Grafana alert manager instances are deployed as a HA cluster https://logzio.atlassian.net/wiki/spaces/DEV/pages/2731311113/Metrics+Alerts+Grafana+8+Alerts#High-Level-Design

When we process alerts, we need to send request to each of the peer in the cluster (deployed as a stateful set and we reference pods by fixed DNS name) so that each peer updates his internal state.

However, apart from updating an internal state it also saves some data in database (annotations and alert instances) which are duplicated (annotations) or causes write lock contention when doing upsert (alert instances).

This change adds a flag to request to prevent saving data in DB if the flag passed as false, when flag passed as true (or not passed) it will keep saving data in DB.

Due to the fact that we have all the URLs of peers in metrics-alerts configuration we can send a request with flag set to true until we have a successful response from the peer - for the rest of peers, we will send request with flag set to false to prevent creating duplicates.