### PR TITLE
DEV-34631 Fix slow query to get authorized alert namespaces + adding user cache on auth

### DIFF
--- a/pkg/models/folders.go
+++ b/pkg/models/folders.go
@@ -113,3 +113,19 @@ type HasAdminPermissionInFoldersQuery struct {
 	SignedInUser *SignedInUser
 	Result       bool
 }
+
+// LOGZ.IO GRAFANA CHANGE :: Refactor query to retrieve visible namespaces for unified alerting rules
+type GetFoldersByUIDsQuery struct {
+	DashboardUIDs []string
+	OrgID         int64
+
+	Result []*FolderRef
+}
+
+type FolderRef struct {
+	Id    int64
+	Uid   string
+	Title string
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end

--- a/pkg/services/contexthandler/authproxy/authproxy.go
+++ b/pkg/services/contexthandler/authproxy/authproxy.go
@@ -340,7 +340,7 @@ func (auth *AuthProxy) GetSignedInUser(userID int64, orgID int64) (*models.Signe
 		UserId: userID,
 	}
 
-	if err := auth.sqlStore.GetSignedInUser(context.Background(), query); err != nil {
+	if err := auth.sqlStore.GetSignedInUserWithCacheCtx(context.Background(), query); err != nil { // LOGZ.IO GRAFANA CHANGE :: Use cache to get signed in user
 		return nil, err
 	}
 

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -93,6 +93,12 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		DataProxy: api.DataProxy,
 	}
 
+	// LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
+	logzioRuleStore := store.LogzioRuleStore{
+		SQLStore: api.SQLStore,
+	}
+	// LOGZ.IO GRAFANA CHANGE :: end
+
 	// Register endpoints for proxying to Alertmanager-compatible backends.
 	api.RegisterAlertmanagerApiEndpoints(NewForkedAM(
 		api.DatasourceCache,
@@ -103,7 +109,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkedProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		&PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore, ac: api.AccessControl},
+		&PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore, ac: api.AccessControl, logzioRuleStore: logzioRuleStore}, // LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkedRuler(
@@ -118,6 +124,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 			log:             logger,
 			cfg:             &api.Cfg.UnifiedAlerting,
 			ac:              api.AccessControl,
+			logzioRuleStore: logzioRuleStore, // LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
 		},
 	), m)
 	api.RegisterTestingApiEndpoints(NewForkedTestingApi(

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -126,7 +126,7 @@ func (f *ForkedRulerApi) forkRouteGetGrafanaRuleGroupConfig(ctx *models.ReqConte
 }
 
 func (f *ForkedRulerApi) forkRouteGetGrafanaRulesConfig(ctx *models.ReqContext) response.Response {
-	return f.GrafanaRuler.RouteGetRulesConfig(ctx)
+	return f.GrafanaRuler.LogzioRouteGetRulesConfig(ctx) // LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
 }
 
 func (f *ForkedRulerApi) forkRoutePostNameGrafanaRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {

--- a/pkg/services/ngalert/api/forked_prom.go
+++ b/pkg/services/ngalert/api/forked_prom.go
@@ -57,5 +57,5 @@ func (f *ForkedPrometheusApi) forkRouteGetGrafanaAlertStatuses(ctx *models.ReqCo
 }
 
 func (f *ForkedPrometheusApi) forkRouteGetGrafanaRuleStatuses(ctx *models.ReqContext) response.Response {
-	return f.GrafanaSvc.RouteGetRuleStatuses(ctx)
+	return f.GrafanaSvc.LogzioRouteGetRuleStatuses(ctx) // LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
 }

--- a/pkg/services/ngalert/store/logzio_alert_rule.go
+++ b/pkg/services/ngalert/store/logzio_alert_rule.go
@@ -1,0 +1,45 @@
+package store
+
+// LOGZ.IO GRAFANA CHANGE :: DEV-34631 - Refactor query to retrieve visible namespaces for unified alerting rules
+
+import (
+	"context"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+type LogzioRuleStore struct {
+	SQLStore *sqlstore.SQLStore
+}
+
+func (st LogzioRuleStore) GetVisibleUserNamespaces(context context.Context, namespaceUid []string, orgId int64, user *models.SignedInUser) (map[string]*models.FolderRef, error) {
+	namespaceMap := make(map[string]*models.FolderRef)
+
+	getDashboardsQuery := buildGetDashboardsTitlesQuery(namespaceUid, orgId, user)
+
+	err := st.SQLStore.GetFoldersByUIDs(context, getDashboardsQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dashboardProj := range getDashboardsQuery.Result {
+		namespaceMap[dashboardProj.Uid] = dashboardProj
+	}
+	return namespaceMap, nil
+}
+
+func buildGetDashboardsTitlesQuery(namespaceUid []string, orgId int64, user *models.SignedInUser) *models.GetFoldersByUIDsQuery {
+	var orgIdFilter int64
+	if orgId == 0 {
+		orgIdFilter = user.OrgId
+	} else {
+		orgIdFilter = orgId
+	}
+
+	return &models.GetFoldersByUIDsQuery{
+		DashboardUIDs: namespaceUid,
+		OrgID:         orgIdFilter,
+	}
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -23,6 +23,15 @@ func (d DashboardPermissionFilter) Where() (string, []interface{}) {
 		return "", nil
 	}
 
+	// LOGZ.IO GRAFANA CHANGE :: DEV-34631 refactor slow query filter
+	/*
+		In logzio setup we always allow to view any folder/dashboard so no need to apply any extra filter
+	*/
+	if d.PermissionLevel == models.PERMISSION_VIEW {
+		return "", nil
+	}
+	// LOGZ.IO GRAFANA CHANGE :: end
+
 	okRoles := []interface{}{d.OrgRole}
 	if d.OrgRole == models.ROLE_EDITOR {
 		okRoles = append(okRoles, models.ROLE_VIEWER)

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -518,7 +518,7 @@ func (ss *SQLStore) GetSignedInUserWithCacheCtx(ctx context.Context, query *mode
 	}
 
 	cacheKey = newSignedInUserCacheKey(query.Result.OrgId, query.UserId)
-	ss.CacheService.Set(cacheKey, *query.Result, time.Second*5)
+	ss.CacheService.Set(cacheKey, *query.Result, time.Second*60) // LOGZ.IO GRAFANA CHANGE :: DEV-34631 Increase cache duration for signed in users
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes two issues with excessive DB usage by Grafana.

1. We use auth proxy mode but in this mode we do not use user cache while it's used in other modes. Added a call to use cached version of get user call. Also, increased cache ttl to 1min because we do not update user in our system ofter.

2. Refactored an API to get rules and get rule statuses not to use complicated DB query to determine accessible folder. This call to DB creates a huge load on mysql and eventually, the CPU usage goes up to 100%. Since we do not use dashboard ACL at all in our setup we can ignore fetching this data.