### PR TITLE
DEV-35480 Alert manager fixes for issues found when enabling to account 300

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -202,7 +202,7 @@ func (hs *HTTPServer) GetAlertNotifiers(ngalertEnabled bool) func(*models.ReqCon
 			availableNotifier := notifier.GetAvailableNotifiers()
 			allowedNotifiers := []alerting.NotifierPlugin{}
 			isAllowedNotifier := func(t string) bool {
-				allowedTypes := []string{"slack", "email", "opsgenie", "victorops", "teams", "webhook", "pagerduty"}
+				allowedTypes := []string{"slack", "email", "opsgenie", "victorops", "teams", "webhook", "pagerduty", "logzio_opsgenie"} // LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Allow type for Opsgenie Logzio intergration
 				isAllowedNotifier := false
 				for _, allowedType := range allowedTypes {
 					if allowedType == t {

--- a/pkg/services/alerting/notifiers/logzio_opsgenie.go
+++ b/pkg/services/alerting/notifiers/logzio_opsgenie.go
@@ -1,0 +1,86 @@
+package notifiers
+
+// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type for logzio Opsgenie integration
+
+import (
+	"context"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/notifications"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const (
+	OpsGenieAlertUrlForLogzioIntegration = "https://api.opsgenie.com/v1/json/logzio"
+)
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "logzio_opsgenie",
+		Name:        "OpsGenie",
+		Description: "Sends notifications to OpsGenie",
+		Heading:     "OpsGenie settings",
+		Factory:     NewLogzioOpsGenieNotifier,
+		Options: []alerting.NotifierOption{
+			{
+				Label:        "API Key",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "OpsGenie API Key",
+				PropertyName: "apiKey",
+				Required:     true,
+				Secure:       true,
+			},
+			{
+				Label:        "Alert API Url",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "https://api.opsgenie.com/v2/alerts",
+				PropertyName: "apiUrl",
+				Required:     true,
+			},
+		},
+	})
+}
+
+// NewOpsGenieNotifier is the constructor for OpsGenie.
+func NewLogzioOpsGenieNotifier(model *models.AlertNotification, fn alerting.GetDecryptedValueFn, ns notifications.Service) (alerting.Notifier, error) {
+	apiKey := fn(context.Background(), model.SecureSettings, "apiKey", model.Settings.Get("apiKey").MustString(), setting.SecretKey)
+	apiURL := model.Settings.Get("apiUrl").MustString()
+	if apiKey == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find api key property in settings"}
+	}
+	if apiURL == "" {
+		apiURL = OpsGenieAlertUrlForLogzioIntegration
+	}
+
+	return &LogzioOpsGenieNotifier{
+		NotifierBase: NewNotifierBase(model, ns),
+		APIKey:       apiKey,
+		APIUrl:       apiURL,
+		log:          log.New("alerting.notifier.logzioopsgenie"),
+	}, nil
+}
+
+// OpsGenieNotifier is responsible for sending
+// alert notifications to OpsGenie
+type LogzioOpsGenieNotifier struct {
+	NotifierBase
+	APIKey string
+	APIUrl string
+	log    log.Logger
+}
+
+// Notify sends an alert notification to OpsGenie.
+func (on *LogzioOpsGenieNotifier) Notify(_ *alerting.EvalContext) error {
+	/**
+	This type of notifier is not used in old alerting and is only served for migrating old notification endpoints
+	to new contact points.
+
+	This method is never expected to be called
+	*/
+	return nil
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -147,7 +147,11 @@ func (e *EmbeddedContactPoint) SecretKeys() ([]string, error) {
 		return []string{}, nil
 	case "wecom":
 		return []string{"url"}, nil
+	// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type to support logzio opsgenie integration
+	case "logzio_opsgenie":
+		return []string{"apiKey"}, nil
 	}
+	// LOGZ.IO GRAFANA CHANGE :: end
 	return nil, fmt.Errorf("no secrets configured for type '%s'", e.Type)
 }
 

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -875,5 +875,24 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 				},
 			},
 		},
+		// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type for logzio Opsgenie integration
+		{
+			Type:        "logzio_opsgenie",
+			Name:        "OpsGenie (Logz.io Integration)",
+			Description: "Sends notifications to OpsGenie. Use this type in case you use Logz.io integration in Opsgenie",
+			Heading:     "OpsGenie settings",
+			Options: []alerting.NotifierOption{
+				{
+					Label:        "API Key",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Placeholder:  "OpsGenie API Key",
+					PropertyName: "apiKey",
+					Required:     true,
+					Secure:       true,
+				},
+			},
+		},
+		// LOGZ.IO GRAFANA CHANGE :: end
 	}
 }

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -878,7 +878,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 		// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type for logzio Opsgenie integration
 		{
 			Type:        "logzio_opsgenie",
-			Name:        "OpsGenie (Logz.io Integration)",
+			Name:        "OpsGenie",
 			Description: "Sends notifications to OpsGenie. Use this type in case you use Logz.io integration in Opsgenie",
 			Heading:     "OpsGenie settings",
 			Options: []alerting.NotifierOption{

--- a/pkg/services/ngalert/notifier/channels/factory.go
+++ b/pkg/services/ngalert/notifier/channels/factory.go
@@ -44,8 +44,9 @@ var receiverFactories = map[string]func(FactoryConfig) (NotificationChannel, err
 	//"googlechat": GoogleChatFactory,
 	//"kafka":      KafkaFactory,
 	//"line":       LineFactory,
-	"opsgenie":  OpsgenieFactory,
-	"pagerduty": PagerdutyFactory,
+	"opsgenie":        OpsgenieFactory,
+	"logzio_opsgenie": LogzioOpsgenieFactory, // LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type for logzio Opsgenie integration
+	"pagerduty":       PagerdutyFactory,
 	//"pushover":   PushoverFactory,
 	//"sensugo":    SensuGoFactory,
 	"slack": SlackFactory,

--- a/pkg/services/ngalert/notifier/channels/logzio_opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/logzio_opsgenie.go
@@ -1,0 +1,193 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/notifications"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"net/http"
+)
+
+// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type for logzio Opsgenie integration
+
+const (
+	OpsGenieAlertUrl = "https://api.opsgenie.com/v1/json/logzio"
+)
+
+type LogzioOpsgenieNotifier struct {
+	*Base
+	APIKey string
+	log    log.Logger
+	tmpl   *template.Template
+	ns     notifications.WebhookSender
+}
+
+type LogzioOpsgenieConfig struct {
+	*NotificationChannelConfig
+	APIKey string
+}
+
+func LogzioOpsgenieFactory(fc FactoryConfig) (NotificationChannel, error) {
+	cfg, err := NewLogzioOpsgenieConfig(fc.Config, fc.DecryptFunc)
+	if err != nil {
+		return nil, receiverInitError{
+			Reason: err.Error(),
+			Cfg:    *fc.Config,
+		}
+	}
+	return NewLogzioOpsgenieNotifier(cfg, fc.NotificationService, fc.Template), nil
+}
+
+func NewLogzioOpsgenieConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedValueFn) (*LogzioOpsgenieConfig, error) {
+	apiKey := decryptFunc(context.Background(), config.SecureSettings, "apiKey", config.Settings.Get("apiKey").MustString())
+	if apiKey == "" {
+		return nil, errors.New("could not find api key property in settings")
+	}
+
+	return &LogzioOpsgenieConfig{
+		NotificationChannelConfig: config,
+		APIKey:                    apiKey,
+	}, nil
+}
+
+// NewOpsgenieNotifier is the constructor for the Opsgenie notifier
+func NewLogzioOpsgenieNotifier(config *LogzioOpsgenieConfig, ns notifications.WebhookSender, t *template.Template) *LogzioOpsgenieNotifier {
+	return &LogzioOpsgenieNotifier{
+		Base: NewBase(&models.AlertNotification{
+			Uid:                   config.UID,
+			Name:                  config.Name,
+			Type:                  config.Type,
+			DisableResolveMessage: config.DisableResolveMessage,
+			Settings:              config.Settings,
+		}),
+		APIKey: config.APIKey,
+		tmpl:   t,
+		log:    log.New("alerting.notifier." + config.Name),
+		ns:     ns,
+	}
+}
+
+func (on *LogzioOpsgenieNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	on.log.Debug("Executing Opsgenie (Logzio Integration) notification", "notification", on.Name)
+
+	alerts := types.Alerts(as...)
+	if alerts.Status() == model.AlertResolved && !on.SendResolved() {
+		on.log.Debug("Not sending a trigger to Opsgenie", "status", alerts.Status(), "auto resolve", on.SendResolved())
+		return true, nil
+	}
+
+	bodyJSON, err := on.buildOpsgenieMessage(ctx, alerts, as)
+	if err != nil {
+		return false, fmt.Errorf("build Opsgenie message: %w", err)
+	}
+
+	body, err := json.Marshal(bodyJSON)
+	if err != nil {
+		return false, fmt.Errorf("marshal json: %w", err)
+	}
+
+	url := fmt.Sprintf("%s?apiKey=%s", OpsGenieAlertUrl, on.APIKey)
+
+	cmd := &models.SendWebhookSync{
+		Url:        url,
+		Body:       string(body),
+		HttpMethod: http.MethodPost,
+		HttpHeader: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	if err := on.ns.SendWebhookSync(ctx, cmd); err != nil {
+		return false, fmt.Errorf("send notification to Opsgenie (Logzio Integration): %w", err)
+	}
+
+	return true, nil
+}
+
+func (on *LogzioOpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts model.Alerts, as []*types.Alert) (payload *simplejson.Json, err error) {
+	key, err := notify.ExtractGroupKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		alias    = key.Hash()
+		bodyJSON = simplejson.New()
+		details  = simplejson.New()
+	)
+
+	if alerts.Status() == model.AlertResolved {
+		bodyJSON := simplejson.New()
+		bodyJSON.Set("alert_alias", alias)
+		bodyJSON.Set("alert_event_type", "close")
+		return bodyJSON, nil
+	}
+
+	rulePageURL := ToLogzioAppPath(joinUrlPath(on.tmpl.ExternalURL.String(), "/alerting/list", on.log))
+
+	var tmplErr error
+	tmpl, data := TmplText(ctx, on.tmpl, as, on.log, &tmplErr)
+
+	var title string
+	var valueString string
+	var alertViewUrl string
+
+	if len(as) == 1 {
+		title = as[0].Name()
+		valueString = string(as[0].Annotations[`__value_string__`])
+		alertViewUrl = as[0].GeneratorURL
+	} else {
+		title = tmpl(DefaultMessageTitleEmbed)
+		alertViewUrl = rulePageURL
+	}
+
+	description := fmt.Sprintf(
+		"%s\n%s\n\n%s",
+		tmpl(DefaultMessageTitleEmbed),
+		rulePageURL,
+		tmpl(`{{ template "default.message" . }}`),
+	)
+
+	// In the new alerting system we've moved away from the grafana-tags. Instead, annotations on the rule itself should be used.
+	lbls := make(map[string]string, len(data.CommonLabels))
+	for k, v := range data.CommonLabels {
+		lbls[k] = tmpl(v)
+	}
+
+	bodyJSON.Set("alert_title", title)
+	bodyJSON.Set("alert_description", description)
+	bodyJSON.Set("alert_alias", alias)
+
+	if valueString != "" {
+		bodyJSON.Set("alert_event_samples", valueString)
+	}
+	bodyJSON.Set("alert_event_type", "create")
+
+	details.Set("url", alertViewUrl)
+	for k, v := range lbls {
+		details.Set(k, v)
+	}
+
+	bodyJSON.Set("alert_details", details)
+	bodyJSON.Set("alert_view_link", alertViewUrl)
+
+	if tmplErr != nil {
+		on.log.Warn("failed to template Opsgenie message (Logzio Integration)", "err", tmplErr.Error())
+	}
+
+	return bodyJSON, nil
+}
+
+func (on *LogzioOpsgenieNotifier) SendResolved() bool {
+	return !on.GetDisableResolveMessage()
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end

--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -164,7 +164,7 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 		// Don't need to run other templates.
 		if on.AutoClose {
 			bodyJSON := simplejson.New()
-			bodyJSON.Set("source", "Grafana")
+			bodyJSON.Set("source", "Logz.io Alert") // LOGZ.IO GRAFANA CHANGE - Remove grafana from notification body
 			apiURL = fmt.Sprintf("%s/%s/close?identifierType=alias", on.APIUrl, alias)
 			return bodyJSON, apiURL, nil
 		}
@@ -199,7 +199,7 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 	}
 
 	bodyJSON.Set("message", title)
-	bodyJSON.Set("source", "Grafana")
+	bodyJSON.Set("source", "Logz.io Alert") // LOGZ.IO GRAFANA CHANGE - Remove grafana from notification body
 	bodyJSON.Set("alias", alias)
 	bodyJSON.Set("description", description)
 	details.Set("url", ruleURL)

--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -205,7 +205,7 @@ func newTestAlert(c apimodels.TestReceiversConfigBodyParams, startsAt, updatedAt
 		}
 		defaultLabels = model.LabelSet{
 			"alertname": "TestAlert",
-			"instance":  "Grafana",
+			"instance":  "Logz.io Alerts", // LOGZ.IO GRAFANA CHANGE - Remove grafana from notification body
 		}
 	)
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -165,6 +165,11 @@ func (a *State) NeedsSending(resendDelay time.Duration) bool {
 	if a.State == eval.Pending || a.State == eval.Normal && !a.Resolved {
 		return false
 	}
+	// LOGZ.IO GRAFANA CHANGE :: DEV-35481 - Do not send a notification on error or no data state
+	if a.State == eval.NoData || a.State == eval.Error {
+		return false
+	}
+	// LOGZ.IO GRAFANA CHANGE :: end
 	// if LastSentAt is before or equal to LastEvaluationTime + resendDelay, send again
 	nextSent := a.LastSentAt.Add(resendDelay)
 	return nextSent.Before(a.LastEvaluationTime) || nextSent.Equal(a.LastEvaluationTime)

--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -369,7 +369,11 @@ func migrateSettingsToSecureSettings(chanType string, settings *simplejson.Json,
 		keys = []string{"apiToken", "userKey"}
 	case "threema":
 		keys = []string{"api_secret"}
+	// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Add type to support logzio opsgenie integration
+	case "logzio_opsgenie":
+		keys = []string{"apiKey"}
 	}
+	// LOGZ.IO GRAFANA CHANGE :: end
 
 	newSecureSettings := secureSettings.Decrypt()
 	cloneSettings := simplejson.New()

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -12,6 +12,10 @@ import { ChannelValues, CommonSettingsComponentType } from '../../../types/recei
 import { ChannelOptions } from './ChannelOptions';
 import { CollapsibleSection } from './CollapsibleSection';
 
+// LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Filter out logzio opsgenie type from creation
+const INTERNAL_CHANNEL_TYPE_PREFIX = 'logzio_';
+// LOGZ.IO GRAFANA CHANGE :: end
+
 interface Props<R> {
   defaultValues: R;
   pathPrefix: string;
@@ -104,7 +108,7 @@ export function ChannelSubForm<R extends ChannelValues>({
                   menuShouldPortal
                   {...field}
                   width={37}
-                  options={typeOptions}
+                  options={typeOptions.filter((o) => !o.value.startsWith(INTERNAL_CHANNEL_TYPE_PREFIX))} // LOGZ.IO GRAFANA CHANGE :: DEV-35483 - Filter out logzio opsgenie type from creation
                   onChange={(value) => onChange(value?.value)}
                 />
               )}


### PR DESCRIPTION
Implemented fixes for issues found when enabling unified alerting for account 300:

1. Create a new contact point type for logzio opsgenie integration to support sending notifications. The reason behind the changes is that when using regular Opsgenie notification flow it does not work with Logzio integration. Thus, we need a new contact point type that only used for existing notification endpoints that rely on logzio integration in opsgenie.

2. In addition to 1, we need to remove an option to select new contact point type when creating a new contact point.

3. Prevent sending notification on error or nodata state to keep the same behavior as it is right now. In order to be notified on error or nodata we can specify alerting which will respect for interval. This helps to minimize number of 'false-positive' alerts in the system.