### PR TITLE
DEV-37746 Add account ID query param to alert notification link in order to be redirected to a correct account

### DIFF
--- a/pkg/services/ngalert/api/logzio_alerting.go
+++ b/pkg/services/ngalert/api/logzio_alerting.go
@@ -128,7 +128,11 @@ func (srv *LogzioAlertingService) RouteProcessAlert(httpReq http.Request, reques
 	if shouldCreateAnnotationsAndAlertInstances {
 		srv.saveAlertStates(processedStates)
 	}
+
 	alerts := schedule.FromAlertStateToPostableAlerts(processedStates, srv.StateManager, srv.AppUrl)
+	for _, alert := range alerts.PostableAlerts {
+		alert.Annotations[ngmodels.LogzioAccountIdAnnotation] = request.AccountId
+	}
 
 	if len(alerts.PostableAlerts) > 0 {
 		n, err := srv.MultiOrgAlertmanager.AlertmanagerFor(alertRule.OrgID)

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -469,6 +469,7 @@ type AlertEvaluationRequest struct {
 }
 
 type AlertProcessRequest struct {
+	AccountId                           string          `json:"accountId"`
 	ShouldManageAnnotationsAndInstances *bool           `json:"shouldManageAnnotationsAndInstances"`
 	AlertRule                           ApiAlertRule    `json:"alertRule"`
 	EvaluationResults                   []ApiEvalResult `json:"evaluationResults"`

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -88,7 +88,8 @@ const (
 	// Annotations are actually a set of labels, so technically this is the label name of an annotation.
 	DashboardUIDAnnotation       = "__dashboardUid__"
 	PanelIDAnnotation            = "__panelId__"
-	AlertRuleStateAnnotationType = "unified_alert_rule" // LOGZ.IO GRAFANA CHANGE :: DEV-31760 - Retrieve annotations for migrated unified alerts
+	AlertRuleStateAnnotationType = "unified_alert_rule"  // LOGZ.IO GRAFANA CHANGE :: DEV-31760 - Retrieve annotations for migrated unified alerts
+	LogzioAccountIdAnnotation    = "__logzioAccountId__" //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 )
 
 // AlertRule is the model for alert rules in unified alerting.

--- a/pkg/services/ngalert/notifier/channels/dingding.go
+++ b/pkg/services/ngalert/notifier/channels/dingding.go
@@ -81,8 +81,8 @@ type DingDingNotifier struct {
 func (dd *DingDingNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	dd.log.Info("Sending dingding")
 
-	// LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
-	ruleURL := ToLogzioAppPath(joinUrlPath(dd.tmpl.ExternalURL.String(), "/alerting/list", dd.log))
+	basePath := ToBasePathWithAccountRedirect(dd.tmpl.ExternalURL, types.Alerts(as...)) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", dd.log))         // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	q := url.Values{
 		"pc_slide": {"false"},

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -113,7 +113,10 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	color, _ := strconv.ParseInt(strings.TrimLeft(getAlertStatusColor(alerts.Status()), "#"), 16, 0)
 	embed.Set("color", color)
 
-	ruleURL := joinUrlPath(d.tmpl.ExternalURL.String(), "/alerting/list", d.log)
+	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	basePath := ToBasePathWithAccountRedirect(d.tmpl.ExternalURL, alerts)
+	ruleURL := joinUrlPath(basePath, "/alerting/list", d.log)
+	//LOGZ.IO GRAFANA CHANGE :: end
 	embed.Set("url", ToLogzioAppPath(ruleURL)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	bodyJSON.Set("embeds", []interface{}{embed})

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -87,9 +87,12 @@ func (en *EmailNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 
 	title := tmpl(DefaultMessageTitleEmbed)
 
-	alertPageURL := en.tmpl.ExternalURL.String()
-	ruleURL := en.tmpl.ExternalURL.String()
-	u, err := url.Parse(en.tmpl.ExternalURL.String())
+	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	basePath := ToBasePathWithAccountRedirect(en.tmpl.ExternalURL, types.Alerts(as...))
+	alertPageURL := basePath
+	ruleURL := basePath
+	u, err := url.Parse(basePath)
+	//LOGZ.IO GRAFANA CHANGE :: end
 	if err == nil {
 		basePath := u.Path
 		u.Path = path.Join(basePath, "/alerting/list")

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -97,7 +97,10 @@ func (gcn *GoogleChatNotifier) Notify(ctx context.Context, as ...*types.Alert) (
 		tmplErr = nil
 	}
 
-	ruleURL := joinUrlPath(gcn.tmpl.ExternalURL.String(), "/alerting/list", gcn.log)
+	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	basePath := ToBasePathWithAccountRedirect(gcn.tmpl.ExternalURL, types.Alerts(as...))
+	ruleURL := joinUrlPath(basePath, "/alerting/list", gcn.log)
+	//LOGZ.IO GRAFANA CHANGE :: end
 	// Add a button widget (link to Grafana).
 	widgets = append(widgets, buttonWidget{
 		Buttons: []button{

--- a/pkg/services/ngalert/notifier/channels/logzio_opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/logzio_opsgenie.go
@@ -136,7 +136,10 @@ func (on *LogzioOpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, aler
 		return bodyJSON, nil
 	}
 
-	rulePageURL := ToLogzioAppPath(joinUrlPath(on.tmpl.ExternalURL.String(), "/alerting/list", on.log))
+	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	basePath := ToBasePathWithAccountRedirect(on.tmpl.ExternalURL, types.Alerts(as...))
+	rulePageURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", on.log))
+	//LOGZ.IO GRAFANA CHANGE :: end
 
 	var tmplErr error
 	tmpl, data := TmplText(ctx, on.tmpl, as, on.log, &tmplErr)

--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -171,7 +171,8 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 		return nil, "", nil
 	}
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(on.tmpl.ExternalURL.String(), "/alerting/list", on.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(on.tmpl.ExternalURL, alerts)      //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", on.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	var tmplErr error
 	tmpl, data := TmplText(ctx, on.tmpl, as, on.log, &tmplErr)

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -163,14 +163,15 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 		details[k] = detail
 	}
 
+	basePath := ToBasePathWithAccountRedirect(pn.tmpl.ExternalURL, alerts) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 	msg := &pagerDutyMessage{
-		Client:      "Grafana",
-		ClientURL:   ToLogzioAppPath(pn.tmpl.ExternalURL.String()), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+		Client:      "Logz.io",
+		ClientURL:   ToLogzioAppPath(basePath), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 		RoutingKey:  pn.Key,
 		EventAction: eventType,
 		DedupKey:    key.Hash(),
 		Links: []pagerDutyLink{{
-			HRef: ToLogzioAppPath(pn.tmpl.ExternalURL.String()), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+			HRef: ToLogzioAppPath(basePath), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 			Text: "External URL",
 		}},
 		Description: tmpl(DefaultMessageTitleEmbed), // TODO: this can be configurable template.

--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -158,7 +158,8 @@ func (pn *PushoverNotifier) SendResolved() bool {
 func (pn *PushoverNotifier) genPushoverBody(ctx context.Context, as ...*types.Alert) (map[string]string, bytes.Buffer, error) {
 	var b bytes.Buffer
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(pn.tmpl.ExternalURL.String(), "/alerting/list", pn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(pn.tmpl.ExternalURL, types.Alerts(as...)) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", pn.log))         // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	alerts := types.Alerts(as...)
 

--- a/pkg/services/ngalert/notifier/channels/sensugo.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo.go
@@ -133,7 +133,8 @@ func (sn *SensuGoNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 		handlers = []string{tmpl(sn.Handler)}
 	}
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(sn.tmpl.ExternalURL.String(), "/alerting/list", sn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(sn.tmpl.ExternalURL, alerts)      //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", sn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 	bodyMsgType := map[string]interface{}{
 		"entity": map[string]interface{}{
 			"metadata": map[string]interface{}{

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -273,7 +273,8 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, as []*types.Aler
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, sn.tmpl, as, sn.log, &tmplErr)
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(sn.tmpl.ExternalURL.String(), "/alerting/list", sn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(sn.tmpl.ExternalURL, alerts)      //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", sn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	//LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones
 	req := &slackMessage{

--- a/pkg/services/ngalert/notifier/channels/teams.go
+++ b/pkg/services/ngalert/notifier/channels/teams.go
@@ -75,7 +75,8 @@ func (tn *TeamsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(tn.tmpl.ExternalURL.String(), "/alerting/list", tn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(tn.tmpl.ExternalURL, types.Alerts(as...)) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", tn.log))         // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 
 	title := tmpl(DefaultMessageTitleEmbed)
 	body := map[string]interface{}{

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -22,6 +22,8 @@ import (
 //For example, if alert goes to Alerting at 13:00, timeframe starts at 12:55
 const alertPanelWindowBeforeTriggerInMinutes = 5 //LOGZ.IO GRAFANA CHANGE :: DEV-32382
 
+const LogzioSwitchToAccountQueryParamName = "switchToAccountId"
+
 type ExtendedAlert struct {
 	Status       string      `json:"status"`
 	Labels       template.KV `json:"labels"`
@@ -60,6 +62,17 @@ func removePrivateItems(kv template.KV) template.KV {
 }
 
 func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *ExtendedAlert {
+	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	accountId := alert.Annotations[ngmodels.LogzioAccountIdAnnotation]
+	var generatorUrl string
+	genUrl, err := url.Parse(alert.GeneratorURL)
+	if err == nil {
+		genUrl = AppendSwitchToAccountQueryParam(genUrl, accountId)
+		generatorUrl = genUrl.String()
+	} else {
+		generatorUrl = alert.GeneratorURL
+	}
+	//LOGZ.IO GRAFANA CHANGE :: end
 	// remove "private" annotations & labels so they don't show up in the template
 	extended := &ExtendedAlert{
 		Status:       alert.Status,
@@ -67,7 +80,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 		Annotations:  removePrivateItems(alert.Annotations),
 		StartsAt:     alert.StartsAt,
 		EndsAt:       alert.EndsAt,
-		GeneratorURL: alert.GeneratorURL,
+		GeneratorURL: generatorUrl, //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 		Fingerprint:  alert.Fingerprint,
 	}
 
@@ -84,13 +97,13 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	dashboardUid := alert.Annotations[ngmodels.DashboardUIDAnnotation]
 	if len(dashboardUid) > 0 {
 		u.Path = path.Join(externalPath, "/d/", dashboardUid)
-		u.RawQuery = appendAlertPanelTimeframeToQueryString(u.RawQuery, alert) //LOGZ.IO GRAFANA CHANGE :: DEV-32382 - Append timeframe for panel/dashboard URL
-		extended.DashboardURL = ToLogzioAppPath(u.String())                    //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones
+		u.RawQuery = appendAlertPanelTimeframeToQueryString(u.RawQuery, alert)                          //LOGZ.IO GRAFANA CHANGE :: DEV-32382 - Append timeframe for panel/dashboard URL
+		extended.DashboardURL = ToLogzioAppPath(AppendSwitchToAccountQueryParam(u, accountId).String()) //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones, DEV-37746: Add switch to account query param
 		panelId := alert.Annotations[ngmodels.PanelIDAnnotation]
 		if len(panelId) > 0 {
 			u.RawQuery = "viewPanel=" + panelId
-			u.RawQuery = appendAlertPanelTimeframeToQueryString(u.RawQuery, alert) //LOGZ.IO GRAFANA CHANGE :: DEV-32382 - Append timeframe for panel/dashboard URL
-			extended.PanelURL = ToLogzioAppPath(u.String())                        //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones
+			u.RawQuery = appendAlertPanelTimeframeToQueryString(u.RawQuery, alert)                      //LOGZ.IO GRAFANA CHANGE :: DEV-32382 - Append timeframe for panel/dashboard URL
+			extended.PanelURL = ToLogzioAppPath(AppendSwitchToAccountQueryParam(u, accountId).String()) //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones, DEV-37746: Add switch to account query param
 		}
 	}
 
@@ -114,6 +127,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	}
 
 	u.RawQuery = query.Encode()
+	u = AppendSwitchToAccountQueryParam(u, accountId) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 	u.RawQuery = ReplaceEncodedSpace(u.RawQuery)      //LOGZ.IO GRAFANA CHANGE :: Replace space encoded as + in silence URL
 	extended.SilenceURL = ToLogzioAppPath(u.String()) //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones
 

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -65,10 +65,10 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 	accountId := alert.Annotations[ngmodels.LogzioAccountIdAnnotation]
 	var generatorUrl string
-	genUrl, err := url.Parse(alert.GeneratorURL)
+	parsedGeneratorUrl, err := ParseLogzioAppPath(alert.GeneratorURL)
 	if err == nil {
-		genUrl = AppendSwitchToAccountQueryParam(genUrl, accountId)
-		generatorUrl = genUrl.String()
+		parsedGeneratorUrl = AppendSwitchToAccountQueryParam(parsedGeneratorUrl, accountId)
+		generatorUrl = ToLogzioAppPath(parsedGeneratorUrl.String())
 	} else {
 		generatorUrl = alert.GeneratorURL
 	}

--- a/pkg/services/ngalert/notifier/channels/threema.go
+++ b/pkg/services/ngalert/notifier/channels/threema.go
@@ -119,12 +119,13 @@ func (tn *ThreemaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 		stateEmoji = "\u2705 " // Check Mark Button
 	}
 
+	basePath := ToBasePathWithAccountRedirect(tn.tmpl.ExternalURL, alerts) //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
 	// Build message
 	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
 		stateEmoji,
 		tmpl(DefaultMessageTitleEmbed),
 		tmpl(`{{ template "default.message" . }}`),
-		ToLogzioAppPath(path.Join(tn.tmpl.ExternalURL.String(), "/alerting/list")), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+		ToLogzioAppPath(path.Join(basePath, "/alerting/list")), // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 	)
 	data.Set("text", message)
 

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -164,6 +164,10 @@ func ToLogzioAppPath(path string) string {
 	return strings.Replace(path, EncodedHashSymbol, "#", 1)
 }
 
+func ParseLogzioAppPath(path string) (*url.URL, error) {
+	return url.Parse(strings.Replace(path, "#", EncodedHashSymbol, 1))
+}
+
 // Golang encode function encodes space as + instead of %20 so we need to replace
 func ReplaceEncodedSpace(path string) string {
 	return strings.Replace(path, "+", EncodedSpaceSymbol, -1)

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"io"
 	"net"
 	"net/http"
@@ -168,7 +169,37 @@ func ReplaceEncodedSpace(path string) string {
 	return strings.Replace(path, "+", EncodedSpaceSymbol, -1)
 }
 
-// LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+//LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
+	updatedUrl := *u
+	builder := strings.Builder{}
+
+	builder.WriteString(u.RawQuery)
+
+	if accountId != "" {
+		if builder.Len() > 0 {
+			builder.WriteString("&")
+		}
+
+		builder.WriteString(LogzioSwitchToAccountQueryParamName)
+		builder.WriteString("=")
+		builder.WriteString(accountId)
+	}
+
+	updatedUrl.RawQuery = builder.String()
+	return &updatedUrl
+}
+
+func ToBasePathWithAccountRedirect(path *url.URL, as model.Alerts) string {
+	var accountId = ""
+	if len(as) > 0 {
+		accountId = string(as[0].Annotations[ngmodels.LogzioAccountIdAnnotation])
+	}
+
+	return AppendSwitchToAccountQueryParam(path, accountId).String()
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end
 
 // GetBoundary is used for overriding the behaviour for tests
 // and set a boundary for multipart body. DO NOT set this outside tests.

--- a/pkg/services/ngalert/notifier/channels/victorops.go
+++ b/pkg/services/ngalert/notifier/channels/victorops.go
@@ -114,7 +114,8 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
 	bodyJSON.Set("monitoring_tool", LogzioFooterText) //LOGZ.IO GRAFANA CHANGE :: DEV-31356: Change grafana default username, footer URL,text to logzio ones
 
-	ruleURL := ToLogzioAppPath(joinUrlPath(vn.tmpl.ExternalURL.String(), "/alerting/list", vn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
+	basePath := ToBasePathWithAccountRedirect(vn.tmpl.ExternalURL, alerts)      //LOGZ.IO GRAFANA CHANGE :: DEV-37746: Add switch to account query param
+	ruleURL := ToLogzioAppPath(joinUrlPath(basePath, "/alerting/list", vn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-31554 - Set APP url to logzio grafana for alert notification URLs
 	bodyJSON.Set("alert_url", ruleURL)
 
 	if tmplErr != nil {


### PR DESCRIPTION
Currently, we do not specify a `switchToAccountId` query param in alert notification link. This creates issues for some of the customers that have multiple sub accounts and they have to manually switch account and only then click the link in the notification.

This PR adds the above query param in all links that exist in alert notifications.

In order to do it, I added a new annotation (internal, not visible to the customer) with the account ID and use it when building a URL. 

URLs affected:
- view alert list url
- view alert url
- silence alert url
- dashboard url
- panel url