### PR TITLE
DEV-37882 Include parsed eval values in notification template

### DIFF
--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -14,8 +14,14 @@ const DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
+{{ define "__eval_value_text" }} - {{ .Var }} [ {{ if .Metric }}metric={{ .Metric }} {{ end }}labels={{ .Labels }} ] = {{ .Value }}{{ end }}
+
+{{ define "__text_values_list" }}{{ if gt (len .EvalValues) 0 }}
+{{ range .EvalValues }}{{ template "__eval_value_text" . }}
+{{ end }}{{ else }}[no value]{{ end }}{{ end }}
+
 {{ define "__text_alert_list" }}{{ range . }}
-Value: {{ or .ValueString "[no value]" }}
+Value: {{ template "__text_values_list" . }}
 Labels:
 {{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end }}Annotations:

--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -11,10 +11,11 @@ import (
 
 const DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
 
+// LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Change template to display evaluation results
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
-{{ define "__eval_value_text" }} - {{ .Var }} [ {{ if .Metric }}metric={{ .Metric }} {{ end }}labels={{ .Labels }} ] = {{ .Value }}{{ end }}
+{{ define "__eval_value_text" }} - {{ .Var }} [ {{ if .Metric }}metric='{{ .Metric }}' {{ end }}labels={{ .Labels }} ] = {{ .Value }}{{ end }}
 
 {{ define "__text_values_list" }}{{ if gt (len .EvalValues) 0 }}
 {{ range .EvalValues }}{{ template "__eval_value_text" . }}
@@ -67,6 +68,8 @@ Annotations:
 {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}**Resolved**
 {{ template "__teams_text_alert_list" .Alerts.Resolved }}{{ end }}{{ end }}
 `
+
+// LOGZ.IO GRAFANA CHANGE :: end
 
 // TemplateForTestsString is the template used for unit tests and integration tests.
 // We have it separate from above default template because any tiny change in the template

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -24,13 +24,16 @@ const alertPanelWindowBeforeTriggerInMinutes = 5 //LOGZ.IO GRAFANA CHANGE :: DEV
 
 const LogzioSwitchToAccountQueryParamName = "switchToAccountId"
 
-// see `extract_md.go` (extractEvalString func) to
+// LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Access evaluation results in grafana alert template
+// see `extract_md.go` (extractEvalString func) so those prefixes match
 const (
 	EvalStrVarNamePrefix = "var='"
 	EvalStrMetricPrefix  = "metric='"
 	EvalStrLabelsPrefix  = "labels="
 	EvalStrValuePrefix   = "value="
 )
+
+// LOGZ.IO GRAFANA CHANGE :: end
 
 type ExtendedAlert struct {
 	Status       string      `json:"status"`
@@ -44,15 +47,18 @@ type ExtendedAlert struct {
 	DashboardURL string      `json:"dashboardURL"`
 	PanelURL     string      `json:"panelURL"`
 	ValueString  string      `json:"valueString"`
-	EvalValues   []EvalValue `json:"evalValues"`
+	EvalValues   []EvalValue `json:"evalValues"` // LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Access evaluation results in grafana alert template
 }
 
+// LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Access evaluation results in grafana alert template
 type EvalValue struct {
 	Var    string
 	Metric string
 	Labels string
 	Value  string
 }
+
+// LOGZ.IO GRAFANA CHANGE :: end
 
 type ExtendedAlerts []ExtendedAlert
 
@@ -237,8 +243,9 @@ func appendAlertPanelTimeframeToQueryString(queryString string, alert template.A
 
 //LOGZ.IO GRAFANA CHANGE :: end
 
-//
+// LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Access evaluation results in grafana alert template
 func parseEvalValues(evaluationStr string) []EvalValue {
+	// Example of eval string - [ var='I0' metric='eu-central-1' labels={region=eu-central-1} value=1 ], metric is optional
 	evalValues := make([]EvalValue, 0)
 
 	if len(evaluationStr) == 0 {
@@ -355,3 +362,5 @@ func parseValue(evalStr string) string {
 
 	return valueStr
 }
+
+// LOGZ.IO GRAFANA CHANGE :: end

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -131,7 +131,7 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 
 	if alert.Annotations != nil {
 		extended.ValueString = alert.Annotations[`__value_string__`]
-		extended.EvalValues = parseEvalValues(extended.ValueString)
+		extended.EvalValues = parseEvalValues(extended.ValueString) // LOGZ.IO GRAFANA CHANGE :: DEV-37882 - Access evaluation results in grafana alert template
 	}
 
 	matchers := make([]string, 0)

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -194,10 +194,10 @@ func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
 	return &updatedUrl
 }
 
-func ToBasePathWithAccountRedirect(path *url.URL, as model.Alerts) string {
+func ToBasePathWithAccountRedirect(path *url.URL, alerts model.Alerts) string {
 	var accountId = ""
-	if len(as) > 0 {
-		accountId = string(as[0].Annotations[ngmodels.LogzioAccountIdAnnotation])
+	if len(alerts) > 0 {
+		accountId = string(alerts[0].Annotations[ngmodels.LogzioAccountIdAnnotation])
 	}
 
 	return AppendSwitchToAccountQueryParam(path, accountId).String()

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -194,10 +194,10 @@ func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
 	return &updatedUrl
 }
 
-func ToBasePathWithAccountRedirect(path *url.URL, alerts model.Alerts) string {
+func ToBasePathWithAccountRedirect(path *url.URL, as model.Alerts) string {
 	var accountId = ""
-	if len(alerts) > 0 {
-		accountId = string(alerts[0].Annotations[ngmodels.LogzioAccountIdAnnotation])
+	if len(as) > 0 {
+		accountId = string(as[0].Annotations[ngmodels.LogzioAccountIdAnnotation])
 	}
 
 	return AppendSwitchToAccountQueryParam(path, accountId).String()


### PR DESCRIPTION
Currently, evaluation values are accessible only as a string in notification template, so the notification sent looks a bit messy:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/61548316/215973954-65a0ac4f-3393-4afe-a370-41b80136976f.png">

especially, if there are more than 1 value that triggers an alert, in such case, the value string looks like this:

<img width="655" alt="image" src="https://user-images.githubusercontent.com/61548316/215974072-91ce4d24-b364-45a6-a9e8-49959e57fbf0.png">

This PR allows to access evaluation values as an object in go templates for alert notifications. The changes are quite minor - we parse evaluation string and build an object out of it.
Also, I changed a default template to have values as a list instead of comma separated values in a string.

Below, there is an example of changes in notification:

<img width="597" alt="image" src="https://user-images.githubusercontent.com/61548316/215974399-31f086ff-dcc5-4f3a-a2a6-7f785a1b987f.png">
