### PR TITLE
DEV-42042 Disable the option to delete or edit the default email

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -52,6 +52,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     setReceiverToDelete(undefined);
   };
 
+  const defaultContactPoint = config.alertmanager_config.route?.receiver;// LOGZ.IO GRAFANA CHANGE
   const rows = useMemo(
     () =>
       config.alertmanager_config.receivers?.map((receiver) => ({
@@ -119,7 +120,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
                 <td className={tableStyles.actionsCell}>
                   {
                     // prettier-ignore
-                    !isVanillaAM && !receiver.logzioSettings && ( // LOGZ.IO GRAFANA CHANGE
+                    !isVanillaAM && !receiver.logzioSettings && defaultContactPoint !== receiver.name && ( // LOGZ.IO GRAFANA CHANGE
                     <>
                       <Authorize actions={[permissions.update]}>
                         <ActionIcon

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -52,7 +52,6 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     setReceiverToDelete(undefined);
   };
 
-  const defaultReceiver = config.alertmanager_config.route?.receiver; // LOGZ.IO GRAFANA CHANGE
   const rows = useMemo(
     () =>
       config.alertmanager_config.receivers?.map((receiver) => ({
@@ -120,7 +119,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
                 <td className={tableStyles.actionsCell}>
                   {
                     // prettier-ignore
-                    !isVanillaAM && !receiver.logzioSettings && defaultReceiver !== receiver.name && ( // LOGZ.IO GRAFANA CHANGE
+                    !isVanillaAM && !receiver.logzioSettings && ( // LOGZ.IO GRAFANA CHANGE
                     <>
                       <Authorize actions={[permissions.update]}>
                         <ActionIcon

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -52,6 +52,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     setReceiverToDelete(undefined);
   };
 
+  const defaultReceiver = config.alertmanager_config.route?.receiver; // LOGZ.IO GRAFANA CHANGE
   const rows = useMemo(
     () =>
       config.alertmanager_config.receivers?.map((receiver) => ({
@@ -119,7 +120,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
                 <td className={tableStyles.actionsCell}>
                   {
                     // prettier-ignore
-                    !isVanillaAM && !receiver.logzioSettings && ( // LOGZ.IO GRAFANA CHANGE
+                    !isVanillaAM && !receiver.logzioSettings && defaultReceiver !== receiver.name && ( // LOGZ.IO GRAFANA CHANGE
                     <>
                       <Authorize actions={[permissions.update]}>
                         <ActionIcon


### PR DESCRIPTION
If the default contact point is edited/delete it "breaks something in our backend."

BEFORE:
<img width="1458" alt="image" src="https://github.com/logzio/data-viz/assets/42069/604bc792-df2c-44ca-b89d-0e1ecc324d90">


AFTER:
<img width="1446" alt="image" src="https://github.com/logzio/data-viz/assets/42069/8a67381d-b3f1-412c-9cb4-7b1d27db93c3">
