### PR TITLE
DEV-42328 Change grafana alert default error state field

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
@@ -72,7 +72,12 @@ export const GrafanaConditionsStep: FC = () => {
           >
             Evaluate every
           </InlineLabel>
-          <Input readOnly={true /* // LOGZ.IO Changes*/} id={evaluateEveryId} width={8} {...register('evaluateEvery', evaluateEveryValidationOptions)} />
+          <Input
+            readOnly={true /* // LOGZ.IO Changes*/}
+            id={evaluateEveryId}
+            width={8}
+            {...register('evaluateEvery', evaluateEveryValidationOptions)}
+          />
           <InlineLabel
             htmlFor={evaluateForId}
             width={7}
@@ -119,6 +124,8 @@ export const GrafanaConditionsStep: FC = () => {
               render={({ field: { onChange, ref, ...field } }) => (
                 <GrafanaAlertStatePicker
                   {...field}
+                  // LOGZ.IO GRAFANA CHANGE :: disable edit of error state handling
+                  disabled
                   inputId="exec-err-state-input"
                   width={42}
                   includeNoData={false}

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -54,7 +54,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     queries: [],
     condition: '',
     noDataState: GrafanaAlertStateDecision.NoData,
-    execErrState: GrafanaAlertStateDecision.Alerting,
+    execErrState: GrafanaAlertStateDecision.OK, // LOGZ.IO GRAFANA CHANGE :: make error query error state OK by default
     evaluateEvery: '1m',
     evaluateFor: '5m',
 


### PR DESCRIPTION
Updated the default state for grafana alert if no data or error.
Disable editing of the field

BEFORE:
<img width="545" alt="image" src="https://github.com/logzio/data-viz/assets/42069/226b6f3a-cc78-4298-82b3-f4392a5fb36e">



AFTER:

<img width="445" alt="image" src="https://github.com/logzio/data-viz/assets/42069/177dffcd-3bd7-4a05-a840-0a9f93b19078">
