### PR TITLE
DEV-42761 Fix playlist share url

### DIFF
--- a/public/app/features/playlist/ShareModal.tsx
+++ b/public/app/features/playlist/ShareModal.tsx
@@ -20,7 +20,7 @@ export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
   const modes: Array<SelectableValue<PlaylistMode>> = [
     { label: 'Normal', value: false },
     { label: 'TV', value: 'tv' },
-    { label: 'Kiosk', value: true },
+    { label: 'Kiosk', value: 'true' },
   ];
 
   const onShareUrlCopy = () => {
@@ -35,7 +35,7 @@ export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
     params.autofitpanels = true;
   }
 
-  const shareUrl = urlUtil.renderUrl(`${buildBaseUrl()}/play/${playlistId}`, params);
+  const shareUrl = urlUtil.renderUrl(`${buildBaseUrl()}/grafana-app/play/${playlistId}`, params);
 
   return (
     <Modal isOpen={true} title="Share playlist" onDismiss={onDismiss}>

--- a/public/app/features/playlist/ShareModal.tsx
+++ b/public/app/features/playlist/ShareModal.tsx
@@ -20,7 +20,7 @@ export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
   const modes: Array<SelectableValue<PlaylistMode>> = [
     { label: 'Normal', value: false },
     { label: 'TV', value: 'tv' },
-    { label: 'Kiosk', value: 'true' },
+    { label: 'Kiosk', value: true },
   ];
 
   const onShareUrlCopy = () => {
@@ -29,13 +29,17 @@ export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
 
   const params: UrlQueryMap = {};
   if (mode) {
-    params.kiosk = mode;
+    params.kiosk = mode.toString();
   }
   if (autoFit) {
     params.autofitpanels = true;
   }
 
-  const shareUrl = urlUtil.renderUrl(`${buildBaseUrl()}/grafana-app/play/${playlistId}`, params);
+  // LOGZ.IO GRAFANA CHANGE :: DEV-42761 fix playlist sharing url
+  const shareUrl = urlUtil.renderUrl(
+    `${buildBaseUrl().replace('playlist', 'grafana-app/playlist')}/play/${playlistId}`,
+    params
+  );
 
   return (
     <Modal isOpen={true} title="Share playlist" onDismiss={onDismiss}>


### PR DESCRIPTION
The share URL must be prefixed with `grafana-app`

BEFORE
![image](https://github.com/logzio/data-viz/assets/42069/01d1a721-698f-4490-8d3a-85fbd25380db)


AFTER

![image](https://github.com/logzio/data-viz/assets/42069/67a5528d-211a-434e-b41e-5886df643c2d)
